### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Enkel
+# Enkel
 
 [![Build Status](https://travis-ci.org/JakubDziworski/Enkel-JVM-language.svg?branch=master)](https://travis-ci.org/JakubDziworski/Enkel-JVM-language)  [![Join the chat at https://gitter.im/JakubDziworski/Enkel-JVM-language](https://badges.gitter.im/JakubDziworski/Enkel-JVM-language.svg)](https://gitter.im/JakubDziworski/Enkel-JVM-language?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Enkel is a simple programming language running on the  jvm
 
-#[Blog - Creating JVM Language] (http://jakubdziworski.github.io/categories.html#Enkel-ref)
+# [Blog - Creating JVM Language] (http://jakubdziworski.github.io/categories.html#Enkel-ref)
  Since day one I've been describing whole project development process on my [blog post series - Creating JVM Language] (http://jakubdziworski.github.io/categories.html#Enkel-ref). 
 It consist of 20 posts covering all the issues.
 When in doubt browsing the code, I encorouge you to take a look at the blog.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
